### PR TITLE
fix knex initialization problem when using sqlite3

### DIFF
--- a/src/config/knexfile.js
+++ b/src/config/knexfile.js
@@ -6,7 +6,7 @@ const {DB_CLIENT, DB_CONNECTION} = process.env
 
 const options = {
   client: DB_CLIENT || 'sqlite3',
-  connection: DB_CONNECTION || path.join(ROOT, 'data/dev.sqlite3'),
+  connection: DB_CONNECTION || { filename: path.join(ROOT, 'data/dev.sqlite3') },
   migrations: {
     directory: path.join(ROOT, 'src/migrations'),
     tableName: 'migrations'

--- a/src/config/knexfile.js
+++ b/src/config/knexfile.js
@@ -30,11 +30,11 @@ module.exports = {
   development: Object.assign({}, options),
 
   test: Object.assign({}, options, {
-    connection: DB_CONNECTION || path.join(ROOT, 'data/test.sqlite3')
+    connection: DB_CONNECTION || { filename: path.join(ROOT, 'data/test.sqlite3') }
   }),
 
   production: Object.assign({}, options, {
-    connection: DB_CONNECTION || path.join(ROOT, 'data/prod.sqlite3')
+    connection: DB_CONNECTION || { filename: path.join(ROOT, 'data/prod.sqlite3') }
   })
 
 }


### PR DESCRIPTION
This PR is to fix the knex initialization error when using sqlite3 (#3) with the solution from @beatgates.
 
I can reproduce the error in Window but not in Mac, not quite sure about the reason.
Generally the solution can work for both cases.

With reference to the [official doc](http://knexjs.org/#Installation-client), the correct initialization config for sqlite3 should contain the _filename_ property.

```
var knex = require('knex')({
  client: 'sqlite3',
  connection: {
    filename: "./mydb.sqlite"
  }
});
```
compared to the PostgreSQL, only connection string is needed
```
var pg = require('knex')({
  client: 'pg',
  connection: process.env.PG_CONNECTION_STRING,
  searchPath: ['knex', 'public'],
});
```

