### PR TITLE
Correct HTTP response to 401 for false login creds

### DIFF
--- a/src/controllers/users-controller.js
+++ b/src/controllers/users-controller.js
@@ -74,7 +74,7 @@ module.exports = {
 
     if (!user) {
       ctx.throw(
-        422,
+        401,
         new ValidationError(['is invalid'], '', 'email or password')
       )
     }
@@ -83,7 +83,7 @@ module.exports = {
 
     if (!isValid) {
       ctx.throw(
-        422,
+        401,
         new ValidationError(['is invalid'], '', 'email or password')
       )
     }


### PR DESCRIPTION
In the event of an incorrect email or password the error response returned should be a 401.