### PR TITLE
BUGFIX: Change HTTP response to 401 for false login creds

### DIFF
--- a/src/controllers/users-controller.js
+++ b/src/controllers/users-controller.js
@@ -64,7 +64,7 @@ module.exports = {
     ctx.assert(
       _.isObject(body.user) && body.user.email && body.user.password,
       422,
-      new ValidationError(["is invalid"], "", "email or password"),
+      new ValidationError(["malformed request"], "", "email or password"),
     )
 
     let user = await db("users")
@@ -73,7 +73,7 @@ module.exports = {
 
     ctx.assert(
       user,
-      422,
+      401,
       new ValidationError(["is invalid"], "", "email or password"),
     )
 
@@ -81,7 +81,7 @@ module.exports = {
 
     ctx.assert(
       isValid,
-      422,
+      401,
       new ValidationError(["is invalid"], "", "email or password"),
     )
 


### PR DESCRIPTION
In the event of an incorrect email or password the error response returned should be a 401.


